### PR TITLE
fix: change start sub-string for figure

### DIFF
--- a/doc_intelligence.py
+++ b/doc_intelligence.py
@@ -188,7 +188,8 @@ def update_figure_description(md_content, img_description, idx):
     """
 
     # The substring you're looking for
-    start_substring = f"![](figures/{idx})"
+    # start_substring = f"![](figures/{idx})"
+    start_substring = f"<figure>"
     end_substring = "</figure>"
     new_string = f"<!-- FigureContent=\"{img_description}\" -->"
     
@@ -280,7 +281,6 @@ def process_figure(input_file_path, figure, idx, md_content, output_folder):
             print(f"\tDescription of figure {idx}: {img_description}")
 
     return idx, img_description, image_url
-
 
 def include_figure_in_md(input_file_path, result, output_folder="/tmp"):
     md_content = result.content


### PR DESCRIPTION
Markdown中から走査するfigureタグを修正。下記の2つが一致しなかったため、Functionsのレスポンスにはfigure descriptionが挿入されていない挙動となっていた。
- Document Intelligenceが出力するfigureタグ
- figure descriptionを挿入する内部処理で走査するfigureタグ